### PR TITLE
unix: also find libreadline.so.8

### DIFF
--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -24,6 +24,7 @@
   (:unix   (:or "libreadline.so.6.3"
                 "libreadline.so.6"
                 "libreadline.so.7"
+                "libreadline.so.8"
                 "libreadline.so"))
   (t       (:default "libreadline")))
 


### PR DESCRIPTION
On my system, */usr/lib/libreadline.so* is a linker script instead of a link to the dynamic library, and CFFI doesn't understand it.
