### PR TITLE
Add libreadline.dylib path for M1 Mac.

### DIFF
--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -27,6 +27,7 @@
   ;; but it is a bad idea, because this command may break some system utilities,
   ;; depending on libedit's internals.
   (:darwin (:or "/usr/local/opt/readline/lib/libreadline.dylib"
+                "/opt/homebrew/opt/readline/lib/libreadline.dylib"
                 "libreadline.dylib"))
   (:unix   (:or "libreadline.so.6.3"
                 "libreadline.so.6"


### PR DESCRIPTION
Homebrew installs libraries under `/opt/homebrew` on M1 Mac, though it uses `/usr/local` for Intel Mac.

https://docs.brew.sh/Installation

<blockquote>
This script installs Homebrew to its preferred prefix (/usr/local for macOS Intel, /opt/homebrew for Apple Silicon and /home/linuxbrew/.linuxbrew for Linux)
</blockquote>
