### PR TITLE
PRODUCE-CALLBACK*: Function variant of PRODUCE-CALLBACK allows CL-REPL to load on CCL

### DIFF
--- a/cl-readline.asd
+++ b/cl-readline.asd
@@ -28,4 +28,5 @@
                  (:file "ctypes")
                  (:file "cl-readline"))
   :depends-on   (:alexandria
-                 :cffi))
+                 :cffi
+                 :conium))

--- a/cl-readline.asd
+++ b/cl-readline.asd
@@ -28,5 +28,4 @@
                  (:file "ctypes")
                  (:file "cl-readline"))
   :depends-on   (:alexandria
-                 :cffi
-                 :conium))
+                 :cffi))

--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -542,22 +542,22 @@ Other values of FUNC will be ignored.
 FUNCTION must be a function, if FUNCTION is NIL, result is unpredictable."
   (case func
     (:getc        (setf *getc-function*
-                        (produce-callback function int-char (:pointer))))
+                        (produce-callback* function int-char '(:pointer))))
     (:redisplay   (setf *redisplay-function*
-                        (produce-callback function :void)))
+                        (produce-callback* function :void)))
     (:prep-term   (setf *prep-term-function*
-                        (produce-callback function :void (:boolean))))
+                        (produce-callback* function :void '(:boolean))))
     (:deprep-term (setf *deprep-term-function*
-                        (produce-callback function :void)))
+                        (produce-callback* function :void)))
     (:complete    (setf *attempted-completion-function*
-                        (produce-callback
+                        (produce-callback*
                          (lambda (text start end)
                            (prog1
                                (to-array-of-strings
                                 (funcall function text start end))
                              (setf *attempted-completion-over* t)))
                          :pointer
-                         (:string :int :int)))))
+                         '(:string :int :int)))))
   nil)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -637,7 +637,7 @@ supplied, binding takes place in specified keymap. If IF-UNBOUND is supplied
 and it's not NIL, KEY will be bound to FUNCTION only if it's not already
 bound."
   (ensure-initialization)
-  (let ((cb (produce-callback function :boolean (:int int-char))))
+  (let ((cb (produce-callback* function :boolean '(:int int-char))))
     (cond ((and keymap if-unbound)
            (foreign-funcall "rl_bind_key_if_unbound_in_map"
                             int-char key
@@ -691,7 +691,7 @@ performed in KEYMAP. If IF-UNBOUND is supplied and it's not NIL, KEYSEQ will
 be bound to FUNCTION only if it's not already bound. The return value is T
 if KEYSEQ is invalid and NIL otherwise."
   (ensure-initialization)
-  (let ((cb (produce-callback function :boolean (:int int-char))))
+  (let ((cb (produce-callback* function :boolean '(:int int-char))))
     (cond ((and keymap if-unbound)
            (foreign-funcall "rl_bind_keyseq_if_unbound_in_map"
                             :string  keyseq

--- a/utils.lisp
+++ b/utils.lisp
@@ -85,20 +85,13 @@ can be ommited if FUNCTION doesn't take any arguments)."
 This avoids using a GENSYM as the name of a callback, and is also funcallable."
   (let ((gensymed-list (mapcar (lambda (x) (list (gensym) x))
                                func-arg-list)))
-    (if function
-        (let ((name (etypecase function
-                      (symbol function)
-                      (function
-                       (let ((name-from-conium
-                               (conium:function-name function)))
-                         (if (and name-from-conium
-                                  (symbolp name-from-conium))
-                             name-from-conium
-                             (gensym)))))))
-          (eval `(defcallback ,name ,return-type ,gensymed-list
-                   (funcall ,function ,@(mapcar #'car gensymed-list))))
-          (get-callback name))
-        (null-pointer))))
+    (with-gensyms (temp)
+      (if function
+          (progn
+            (eval `(defcallback ,temp ,return-type ,gensymed-list
+                     (funcall ,function ,@(mapcar #'car gensymed-list))))
+            (get-callback temp))
+          (null-pointer)))))
 
 (defun to-list-of-strings (pointer)
   "Convert a null-terminated array of pointers to chars that POINTER points

--- a/utils.lisp
+++ b/utils.lisp
@@ -80,6 +80,26 @@ can be ommited if FUNCTION doesn't take any arguments)."
              (get-callback ',temp))
            (null-pointer)))))
 
+(defun produce-callback* (function return-type &optional func-arg-list)
+  "Variant of PRODUCE-CALLBACK that should hopefully be more portable.
+This avoids using a GENSYM as the name of a callback, and is also funcallable."
+  (let ((gensymed-list (mapcar (lambda (x) (list (gensym) x))
+                               func-arg-list)))
+    (if function
+        (let ((name (etypecase function
+                      (symbol function)
+                      (function
+                       (let ((name-from-conium
+                               (conium:function-name function)))
+                         (if (and name-from-conium
+                                  (symbolp name-from-conium))
+                             name-from-conium
+                             (gensym)))))))
+          (eval `(defcallback ,name ,return-type ,gensymed-list
+                   (funcall ,function ,@(mapcar #'car gensymed-list))))
+          (get-callback name))
+        (null-pointer))))
+
 (defun to-list-of-strings (pointer)
   "Convert a null-terminated array of pointers to chars that POINTER points
 to into list of Lisp strings."


### PR DESCRIPTION
This does require additional changes in CL-REPL that I am currently working on; but with both of these, CL-REPL can work on CCL. As things stand at the moment, trying to load CL-REPL on CCL results in the following error:

```
The value (:INTERNAL CFFI-CALLBACKS::|#::TEMP5092|
           CL-READLINE:BIND-KEYSEQ) is not of the expected type (AND
                                                                 SYMBOL
                                                                 (NOT
                                                                  (SATISFIES
                                                                   CONSTANTP))).
   [Condition of type TYPE-ERROR]

Backtrace:
  0: (CCL::DEFINE-CALLBACK-FUNCTION #<COMPILED-LEXICAL-CLOSURE (:INTERNAL CFFI-CALLBACKS::|#::TEMP5092| CL-READLINE:BIND-KEYSEQ) #x302001B2AF6F> NIL NIL NIL)
  1: (CL-READLINE:BIND-KEYSEQ "\\C-r" #<Compiled-function CL-REPL::UNBIND-KEY #x302001B2BEAF> :KEYMAP #<A Foreign Pointer #x7FF6A0031E60> :IF-UNBOUND NIL)
  2: (#<Anonymous Function #x302001B2B5EF>)
  3: (CCL::$FASL-LFUNCALL #<CCL::FASLSTATE #x7FF6B93CEBCD>)
  4: (CCL::%FASLOAD "/home/user/.cache/common-lisp/ccl-1.12-f98-linux-x64/home/user/quicklisp/local-projects/cl-repl/src/keymap.lx64fsl" #(#<Compiled-function CCL::$FASL-NOOP (Non-Global)  #x30..
  5: (CCL::%LOAD #P"/home/user/.cache/common-lisp/ccl-1.12-f98-linux-x64/home/user/quicklisp/local-projects/cl-repl/src/keymap.lx64fsl" NIL NIL :ERROR :DEFAULT NIL)
  6: (LOAD #P"/home/user/.cache/common-lisp/ccl-1.12-f98-linux-x64/home/user/quicklisp/local-projects/cl-repl/src/keymap.lx64fsl" :VERBOSE NIL :PRINT NIL :IF-DOES-NOT-EXIST :ERROR :EXTERNAL-FOR..

...
```