### PR TITLE
Add *blink-matching-paren*

### DIFF
--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -1043,6 +1043,9 @@ append text to the file instead of overwriting it."
                      :boolean readable
                      :void)))
 
+(defcvar ("rl_blink_matching_paren" *blink-matching-paren*) :boolean
+  "If this variable is non-NIL, matching parenthesis will blink whenever the closing parenthesis is inserted.")
+
 (defcfun ("rl_set_paren_blink_timeout" set-paren-blink-timeout) :int
   "Set the time interval (in microseconds) that Readline waits when showing
 a balancing character when 'blink-matching-paren' has been enabled. The

--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -1044,7 +1044,8 @@ append text to the file instead of overwriting it."
                      :void)))
 
 (defcvar ("rl_blink_matching_paren" *blink-matching-paren*) :boolean
-  "If this variable is non-NIL, matching parenthesis will blink whenever the closing parenthesis is inserted.")
+  "If this variable is non-NIL, matching parenthesis (if its key is bound to
+rl_insert_close) will blink whenever the closing parenthesis is inserted.")
 
 (defcfun ("rl_set_paren_blink_timeout" set-paren-blink-timeout) :int
   "Set the time interval (in microseconds) that Readline waits when showing

--- a/package.lisp
+++ b/package.lisp
@@ -128,6 +128,7 @@
    #:variable-bind
    #:variable-value
    #:variable-dumper
+   #:*blink-matching-paren*
    #:set-paren-blink-timeout
    #:clear-history
    #:read-history


### PR DESCRIPTION
As suggested in https://github.com/vindarel/cl-readline/issues/17, this is necessary to get matching paren blinking in CL-REPL, but not sufficient. This also requires the closing parenthesis keys to be bound to `rl_insert_close`. Once both these are done (as in https://github.com/digikar99/cl-repl/commit/ddf324133272e14222451a753d6cc1ced0470328), matching parentheses blink!