### PR TITLE
openbsd: use libereadline.so

### DIFF
--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -30,6 +30,7 @@
                 "/opt/homebrew/opt/readline/lib/libreadline.dylib"
                 "/opt/local/lib/libreadline.dylib"
                 "libreadline.dylib"))
+  (:openbsd (:default "libereadline"))
   (:unix   (:or "libreadline.so.6.3"
                 "libreadline.so.6"
                 "libreadline.so.7"


### PR DESCRIPTION
on OpenBSD, there is several versions of readline library.

the base system has an relatively old version (named libreadline.so), and user could install a recent library (named libereadline.so) using ports system.

the base version is too old and incompatible with cl-readline. prefer to use the port version one.