### PR TITLE
Correctly load libreadline DLL on Windows

### DIFF
--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -36,6 +36,10 @@
                 "libreadline.so.7"
                 "libreadline.so.8"
                 "libreadline.so"))
+  ;; On windows, this assumes that the libreadline is installed with msys2 
+  ;; and built with the mingw64 toolchain. The msys2/mingw64/bin directory
+  ;; needs to be on %PATH%
+  (:windows (:or "libreadline8.dll"))
   (t       (:default "libreadline")))
 
 (use-foreign-library readline)

--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -39,7 +39,8 @@
   ;; On windows, this assumes that the libreadline is installed with msys2 
   ;; and built with the mingw64 toolchain. The msys2/mingw64/bin directory
   ;; needs to be on %PATH%
-  (:windows (:or "libreadline8.dll"))
+  (:windows (:or "libreadline8.dll"
+		 "libreadline.dll"))
   (t       (:default "libreadline")))
 
 (use-foreign-library readline)


### PR DESCRIPTION
This adds logic to correctly pick up libreadline library on Windows.

The assumption is that libreadline has been installed with msys2, specifically the mingw64 distribution. Based on my research this is a fairly common way to install readline - I am not actually aware of any other ways, though there could be. The gotcha here is that the `msys2/mingw64/bin` directory must be on `%PATH%` (that's not a typo - it's the **bin** directory, **not the lib directory**).

The most current name for the dll is `libreadline8.dll`.

I was able to successfully use your `cl-readline-example` to verify this works. I'm using `sbcl`  2.4.9 on Windows 11.

EDIT: I added a fallback to the default "libreadline.dll" - just in case someone has copied the DLL to somewhere on `%PATH%` or has it available as a checked-in binary under that name.