### PR TITLE
Package related style improvements

### DIFF
--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -56,60 +56,60 @@
 ;; The documentation can be found at
 ;; http://cnswww.cns.cwru.edu/php/chet/readline/readline.html
 
-(defcvar ("rl_line_buffer" *line-buffer*) :string
+(cffi:defcvar ("rl_line_buffer" *line-buffer*) :string
   "This is the line gathered so far. You are welcome to modify the contents
 of the line, but remember about undoing. The function `extend-line-buffer'
 is available to increase the memory allocated to `*line-buffer*'.")
 
 ;; rl_point is the place in the string where the cursor is.  Sometimes
 ;; this is the same as rl_end.
-(defcvar ("rl_point" *point*) :int
+(cffi:defcvar ("rl_point" *point*) :int
   "The offset of the current cursor position in `*line-buffer*' (the
 point).")
 
-(defcvar ("rl_end" +end+ :read-only t) :int
+(cffi:defcvar ("rl_end" +end+ :read-only t) :int
   "The number of characters present in `*line-buffer*'. When `*point*' is at
 the end of the line, `*point*' and `+end+' are equal.")
 
-(defcvar ("rl_mark" *mark*) :int
+(cffi:defcvar ("rl_mark" *mark*) :int
   "The mark (saved position) in the current line. If set, the mark and point
 define a region.")
 
-(defcvar ("rl_done" *done*) :boolean
+(cffi:defcvar ("rl_done" *done*) :boolean
   "Setting this to a non-NIL value causes Readline to return the current
 line immediately.")
 
-(defcvar ("rl_num_chars_to_read" *num-chars-to-read*) :int
+(cffi:defcvar ("rl_num_chars_to_read" *num-chars-to-read*) :int
   "Setting this to a positive value before calling READLINE causes Readline
 to return after accepting that many characters, rather than reading up to a
 character bound to accept-line.")
 
-(defcvar ("rl_pending_input" *pending-input*) :int ;; not used
+(cffi:defcvar ("rl_pending_input" *pending-input*) :int ;; not used
   "Setting this to a value makes it the next keystroke read. This is a way
 to stuff a single character into the input stream.")
 
-(defcvar ("rl_dispatching" +dispatching+ :read-only t) :boolean
+(cffi:defcvar ("rl_dispatching" +dispatching+ :read-only t) :boolean
   "Set to a non-NIL value if a function is being called from a key binding;
 NIL otherwise. Application functions can test this to discover whether they
 were called directly or by Readline's dispatching mechanism.")
 
-(defcvar ("rl_erase_empty_line" *erase-empty-line*) :boolean
+(cffi:defcvar ("rl_erase_empty_line" *erase-empty-line*) :boolean
   "Setting this to a non-NIL value causes Readline to completely erase the
 current line, including any prompt, any time a newline is typed as the only
 character on an otherwise-empty line. The cursor is moved to the beginning
 of the newly-blank line.")
 
-(defcvar ("rl_prompt" +prompt+ :read-only t) :string
+(cffi:defcvar ("rl_prompt" +prompt+ :read-only t) :string
   "The prompt Readline uses. This is set from the argument to `readline',
 and should not be assigned to directly. The `set-prompt' function may be
 used to modify the prompt string after calling `readline'.")
 
-(defcvar ("rl_display_prompt" *display-prompt*) :string
+(cffi:defcvar ("rl_display_prompt" *display-prompt*) :string
   "The string displayed as the prompt. This is usually identical to
 `+prompt+', but may be changed temporarily by functions that use the prompt
 string as a message area, such as incremental search.")
 
-(defcvar ("rl_already_prompted" *already-prompted*) :boolean
+(cffi:defcvar ("rl_already_prompted" *already-prompted*) :boolean
   "If an application wishes to display the prompt itself, rather than have
 Readline do it the first time READLINE is called, it should set this
 variable to a non-NIL value after displaying the prompt. The prompt must
@@ -117,146 +117,146 @@ also be passed as the argument to READLINE so the redisplay functions can
 update the display properly. The calling application is responsible for
 managing the value; Readline never sets it.")
 
-(defcvar ("rl_library_version" +library-version+ :read-only t) :string
+(cffi:defcvar ("rl_library_version" +library-version+ :read-only t) :string
   "The version number of this revision of the library.")
 
-(defcvar ("rl_readline_version" +readline-version+ :read-only t) version
+(cffi:defcvar ("rl_readline_version" +readline-version+ :read-only t) version
   "Major and minor version numbers of Readline library.")
 
-(defcvar ("rl_gnu_readline_p" +gnu-readline-p+ :read-only t) :boolean
+(cffi:defcvar ("rl_gnu_readline_p" +gnu-readline-p+ :read-only t) :boolean
   "Always evaluated to T, denoting that this is GNU readline rather than
 some emulation.")
 
-(defcvar ("rl_terminal_name" *terminal-name*) :string
+(cffi:defcvar ("rl_terminal_name" *terminal-name*) :string
   "The terminal type, used for initialization. If not set by the
 application, Readline sets this to the value of the TERM environment
 variable the first time it is called.")
 
-(defcvar ("rl_readline_name" *readline-name*) :string
+(cffi:defcvar ("rl_readline_name" *readline-name*) :string
   "This symbol-macro should be set to a unique name by each application
 using Readline. The value allows conditional parsing of the inputrc file.")
 
-(defcvar ("rl_instream" *instream*) :pointer ;; not used
+(cffi:defcvar ("rl_instream" *instream*) :pointer ;; not used
   "The stdio stream from which Readline reads input. If NULL, Readline
 defaults to stdin.")
 
-(defcvar ("rl_outstream" *outstream*) :pointer
+(cffi:defcvar ("rl_outstream" *outstream*) :pointer
   "The stdio stream to which Readline performs output. If NULL, Readline
 defaults to stdout.")
 
-(defcvar ("rl_prefer_env_winsize" *prefer-env-winsize*) :boolean
+(cffi:defcvar ("rl_prefer_env_winsize" *prefer-env-winsize*) :boolean
   "If non-NIL, Readline gives values found in the LINES and COLUMNS
 environment variables greater precedence than values fetched from the kernel
 when computing the screen dimensions.")
 
-(defcvar ("rl_last_func" *last-func*) :pointer ;; not used
+(cffi:defcvar ("rl_last_func" *last-func*) :pointer ;; not used
   "The address of the last command function Readline executed. May be used
 to test whether or not a function is being executed twice in succession, for
 example.")
 
-(defcvar ("rl_startup_hook" *startup-hook*) :pointer
+(cffi:defcvar ("rl_startup_hook" *startup-hook*) :pointer
   "If non-zero, this is the address of a function to call just before
 readline prints the first prompt.")
 
-(defcvar ("rl_pre_input_hook" *pre-input-hook*) :pointer
+(cffi:defcvar ("rl_pre_input_hook" *pre-input-hook*) :pointer
   "If non-zero, this is the address of a function to call after the first
 prompt has been printed and just before readline starts reading input
 characters.")
 
-(defcvar ("rl_event_hook" *event-hook*) :pointer
+(cffi:defcvar ("rl_event_hook" *event-hook*) :pointer
   "If non-zero, this is the address of a function to call periodically when
 Readline is waiting for terminal input. By default, this will be called at
 most ten times a second if there is no keyboard input.")
 
-(defcvar ("rl_getc_function" *getc-function*) :pointer
+(cffi:defcvar ("rl_getc_function" *getc-function*) :pointer
   "If non-zero, Readline will call indirectly through this pointer to get a
 character from the input stream. By default, it is set to `rl_getc', the
 default Readline character input function (see section 2.4.8 Character
 Input). In general, an application that sets `rl_getc_function' should
 consider setting `rl_input_available_hook' as well.")
 
-(defcvar ("rl_signal_event_hook" *signal-event-hook*) :pointer
+(cffi:defcvar ("rl_signal_event_hook" *signal-event-hook*) :pointer
   "If non-zero, this is the address of a function to call if a read system
 call is interrupted when Readline is reading terminal input.")
 
-(defcvar ("rl_input_available_hook" *input-available-hook*) :pointer
+(cffi:defcvar ("rl_input_available_hook" *input-available-hook*) :pointer
   "If non-zero, Readline will use this function's return value when it needs
 to determine whether or not there is available input on the current input
 source.")
 
-(defcvar ("rl_redisplay_function" *redisplay-function*) :pointer
+(cffi:defcvar ("rl_redisplay_function" *redisplay-function*) :pointer
   "If non-zero, Readline will call indirectly through this pointer to update
 the display with the current contents of the editing buffer. By default, it
 is set to `rl_redisplay', the default Readline redisplay function (see
 section 2.4.6 Redisplay).")
 
-(defcvar ("rl_prep_term_function" *prep-term-function*) :pointer
+(cffi:defcvar ("rl_prep_term_function" *prep-term-function*) :pointer
   "If non-zero, Readline will call indirectly through this pointer to
 initialize the terminal. The function takes a single argument, an int flag
 that says whether or not to use eight-bit characters. By default, this is
 set to `rl_prep_terminal' (see section 2.4.9 Terminal Management).")
 
-(defcvar ("rl_deprep_term_function" *deprep-term-function*) :pointer
+(cffi:defcvar ("rl_deprep_term_function" *deprep-term-function*) :pointer
   "If non-zero, Readline will call indirectly through this pointer to reset
 the terminal. This function should undo the effects of
 `rl_prep_term_function.' By default, this is set to
 `rl_deprep_terminal' (see section 2.4.9 Terminal Management).")
 
-(defcvar ("rl_executing_keymap" +executing-keymap+ :read-only t) :pointer
+(cffi:defcvar ("rl_executing_keymap" +executing-keymap+ :read-only t) :pointer
   "This symbol macro is evaluated to the keymap in which the currently
 executing Readline function was found.")
 
-(defcvar ("rl_binding_keymap" +binding-keymap+ :read-only t) :pointer
+(cffi:defcvar ("rl_binding_keymap" +binding-keymap+ :read-only t) :pointer
   "This symbol macro is evaluated to the keymap in which the last key
 binding occurred.")
 
-(defcvar ("rl_executing_macro" +executing-macro+ :read-only t) :string
+(cffi:defcvar ("rl_executing_macro" +executing-macro+ :read-only t) :string
   "This symbol macro is evaluated to the text of any currently-executing
 macro.")
 
-(defcvar ("rl_executing_key" +executing-key+ :read-only t) int-char
+(cffi:defcvar ("rl_executing_key" +executing-key+ :read-only t) int-char
   "The key that caused the dispatch to the currently-executing Readline
 function.")
 
-(defcvar ("rl_executing_keyseq" +executing-keyseq+ :read-only t) :string
+(cffi:defcvar ("rl_executing_keyseq" +executing-keyseq+ :read-only t) :string
   "The full key sequence that caused the dispatch to the currently-executing
 Readline function.")
 
-(defcvar ("rl_key_sequence_length" +key-sequence-length+ :read-only t) :int
+(cffi:defcvar ("rl_key_sequence_length" +key-sequence-length+ :read-only t) :int
   "The number of characters in `+executing-keyseq+'.")
 
-(defcvar ("rl_readline_state" +readline-state+ :read-only t) state
+(cffi:defcvar ("rl_readline_state" +readline-state+ :read-only t) state
   "This symbol macro is evaluated to a list containing keywords that denote
 state of Readline. For list of possible values see `+states+'.")
 
-(defcvar ("rl_explicit_arg" +explicit-arg+ :read-only t) :boolean
+(cffi:defcvar ("rl_explicit_arg" +explicit-arg+ :read-only t) :boolean
   "Evaluated to T if an explicit numeric argument was specified by the
 user. Only valid in a bindable command function.")
 
-(defcvar ("rl_numeric_arg" +numeric-arg+ :read-only t) :int
+(cffi:defcvar ("rl_numeric_arg" +numeric-arg+ :read-only t) :int
   "Evaluated to the value of any numeric argument explicitly specified by
 the user before executing the current Readline function. Only valid in a
 bindable command function.")
 
-(defcvar ("rl_editing_mode" +editing-mode+ :read-only t) editing-mode
+(cffi:defcvar ("rl_editing_mode" +editing-mode+ :read-only t) editing-mode
   "Evaluated to keyword denoting actual editing mode: :EMACS or :VI.")
 
-(defcvar ("rl_catch_signals" *catch-signals*) :boolean
+(cffi:defcvar ("rl_catch_signals" *catch-signals*) :boolean
   "If this variable is non-NIL, Readline will install signal handlers for
 SIGINT, SIGQUIT, SIGTERM, SIGHUP, SIGALRM, SIGTSTP, SIGTTIN, and
 SIGTTOU. The default value of `*catch-signals*' is T.")
 
-(defcvar ("rl_catch_sigwinch" *catch-sigwinch*) :boolean
+(cffi:defcvar ("rl_catch_sigwinch" *catch-sigwinch*) :boolean
   "If this variable is set to a non-NIL value, Readline will install a
 signal handler for SIGWINCH. The default value of `*catch-sigwinch*' is T.")
 
-(defcvar ("rl_change_environment" *change-environment*) :boolean
+(cffi:defcvar ("rl_change_environment" *change-environment*) :boolean
   "If this variable is set to a non-NIL value, and Readline is handling
 SIGWINCH, Readline will modify the LINES and COLUMNS environment variables
 upon receipt of a SIGWINCH. The default value of `*change-environment*' is
 T.")
 
-(defcvar ("rl_attempted_completion_function"
+(cffi:defcvar ("rl_attempted_completion_function"
           *attempted-completion-function*)
     :pointer
   "A pointer to an alternative function to create matches. The function is
@@ -269,7 +269,7 @@ strings returned will be used. If this function sets the
 `*attempted-completion-over*' variable to a non-NIL value, Readline will not
 perform its default completion even if this function returns no matches.")
 
-(defcvar ("rl_completion_display_matches_hook"
+(cffi:defcvar ("rl_completion_display_matches_hook"
           *completion-display-matches-hook*)
     :pointer
   "If non-zero, then this is the address of a function to call when
@@ -280,30 +280,30 @@ is the array of matching strings, `num_matches' is the number of strings in
 that array, and `max_length' is the length of the longest string in that
 array.")
 
-(defcvar ("rl_basic_word_break_characters"
+(cffi:defcvar ("rl_basic_word_break_characters"
           *basic-word-break-characters*)
     :string
   "The basic list of characters that signal a break between words for the
 completer routine. The default value of this variable is the characters
 which break words for completion in Bash.")
 
-(defcvar ("rl_basic_quote_characters" *basic-quote-characters*) :string
+(cffi:defcvar ("rl_basic_quote_characters" *basic-quote-characters*) :string
   "A list of quote characters which can cause a word break.")
 
-(defcvar ("rl_completer_word_break_characters"
+(cffi:defcvar ("rl_completer_word_break_characters"
           *completer-word-break-characters*)
     :string
   "The list of characters that signal a break between words for
 `complete-internal'. The default list is the value of
 `*basic-word-break-characters*.'")
 
-(defcvar ("rl_completion_query_items" *completion-query-items*) :int
+(cffi:defcvar ("rl_completion_query_items" *completion-query-items*) :int
   "Up to this many items will be displayed in response to a
 `possible-completions' call. After that, Readline asks the user if she is
 sure she wants to see them all. The default value is 100. A negative value
 indicates that Readline should never ask the user.")
 
-(defcvar ("rl_completion_append_character" *completion-append-character*)
+(cffi:defcvar ("rl_completion_append_character" *completion-append-character*)
     int-char
   "When a single completion alternative matches at the end of the command
 line, this character is appended to the inserted completion text. The
@@ -313,12 +313,12 @@ application-specific completion functions to provide the 'most sensible word
 separator character' according to an application-specific command line
 syntax specification.")
 
-(defcvar ("rl_ignore_completion_duplicates" *ignore-completion-duplicates*)
+(cffi:defcvar ("rl_ignore_completion_duplicates" *ignore-completion-duplicates*)
     :boolean
   "If non-NIL, then duplicates in the matches are removed. The default is
 T.")
 
-(defcvar ("rl_attempted_completion_over" *attempted-completion-over*)
+(cffi:defcvar ("rl_attempted_completion_over" *attempted-completion-over*)
     :boolean
   "If an application-specific completion function assigned to
 `*attempted-completion-function*' sets this variable to a non-NIL value,
@@ -326,7 +326,7 @@ Readline will not perform its default filename completion even if the
 application's completion function returns no matches. It should be set only
 by an application's completion function.")
 
-(defcvar ("rl_sort_completion_matches" *sort-completion-matches*)
+(cffi:defcvar ("rl_sort_completion_matches" *sort-completion-matches*)
     :boolean
   "If an application sets this variable to NIL, Readline will not sort the
 list of completions (which implies that it cannot remove any duplicate
@@ -335,7 +335,7 @@ the completions and, depending on the value of
 `*ignore-completion-duplicates*', will attempt to remove duplicate
 matches.")
 
-(defcvar ("rl_completion_type" +completion-type+ :read-only t) completion-type
+(cffi:defcvar ("rl_completion_type" +completion-type+ :read-only t) completion-type
   "Set to a keyword describing the type of completion Readline is currently
 attempting. Possible values are:
 
@@ -352,14 +352,14 @@ more than one, as well as performing partial completion;
 completions are not listed if the possible completions share a common
 prefix.")
 
-(defcvar ("rl_inhibit_completion" *inhibit-completion*) :boolean
+(cffi:defcvar ("rl_inhibit_completion" *inhibit-completion*) :boolean
   "If this variable is non-NIL, completion is inhibited. The completion
 character will be inserted as any other bound to self-insert.")
 
-(defcvar ("history_base" +history-base+ :read-only t) :int
+(cffi:defcvar ("history_base" +history-base+ :read-only t) :int
   "The logical offset of the first entry in the history list.")
 
-(defcvar ("history_length" +history-length+ :read-only t) :int
+(cffi:defcvar ("history_length" +history-length+ :read-only t) :int
   "The number of entries currently stored in the history list.")
 
 
@@ -378,7 +378,7 @@ PREDICATE. Return T if there is no history saved."
                  (foreign-string-to-lisp
                   (with-foreign-slots
                       ((line)
-                       (foreign-funcall "history_get"
+                       (cffi:foreign-funcall "history_get"
                                         :int (1- (+ +history-base+
                                                     +history-length+))
                                         :pointer)
@@ -411,10 +411,10 @@ actual string and NIL on failure."
         *num-chars-to-read* (or num-chars 0)
         *erase-empty-line*  erase-empty-line)
   (let* ((prompt (if prompt (string prompt) ""))
-         (ptr (foreign-funcall "readline"
+         (ptr (cffi:foreign-funcall "readline"
                                :string prompt
                                :pointer)))
-    (unless (null-pointer-p ptr))
+    (unless (cffi:null-pointer-p ptr))
       (unwind-protect
            (let ((str (cffi:foreign-string-to-lisp ptr)))
              (when (and add-history
@@ -422,11 +422,11 @@ actual string and NIL on failure."
                         (or (not novelty-check)
                             (recent-history-line-satisfies-p
                              (alexandria:curry novelty-check str))))
-               (foreign-funcall "add_history"
+               (cffi:foreign-funcall "add_history"
                                 :string str
                                 :void))
              str)
-        (foreign-funcall "free"
+        (cffi:foreign-funcall "free"
                          :pointer ptr
                          :void))))
 
@@ -442,22 +442,22 @@ temporarily reassign `*outstream*' to pointer to this file, perform BODY,
 then close the file and assign `*outstream*' the old value. If APPEND is not
 NIL, output will be appended to the file. Returns NIL on success and T on
 failure."
-  (with-gensyms (temp-outstream file-pointer body-fnc)
+  (alexandria:with-gensyms (temp-outstream file-pointer body-fnc)
     `(flet ((,body-fnc ()
               ,@body))
        (if ,filename
            (let ((,temp-outstream *outstream*)
-                 (,file-pointer (foreign-funcall "fopen"
+                 (,file-pointer (cffi:foreign-funcall "fopen"
                                                  :string ,filename
                                                  :string (if ,append "a" "w")
                                                  :pointer)))
-             (if (null-pointer-p ,file-pointer)
+             (if (cffi:null-pointer-p ,file-pointer)
                  t
                  (unwind-protect
                       (progn
                         (setf *outstream* ,file-pointer)
                         (,body-fnc))
-                   (foreign-funcall "fclose"
+                   (cffi:foreign-funcall "fclose"
                                     :pointer ,file-pointer
                                     :boolean)
                    (setf *outstream* ,temp-outstream))))
@@ -584,32 +584,32 @@ lowercase Meta characters bound to run their equivalents, and the Meta
 digits bound to produce numeric arguments. If BARE is supplied and it's not
 NIL, empty keymap will be returned."
   (if bare
-      (foreign-funcall "rl_make_bare_keymap"
+      (cffi:foreign-funcall "rl_make_bare_keymap"
                        :pointer)
-      (foreign-funcall "rl_make_keymap"
+      (cffi:foreign-funcall "rl_make_keymap"
                        :pointer)))
 
-(defcfun ("rl_copy_keymap" copy-keymap) :pointer
+(cffi:defcfun ("rl_copy_keymap" copy-keymap) :pointer
   "Return a new keymap which is a copy of KEYMAP."
   (keymap :pointer))
 
-(defcfun ("rl_free_keymap" free-keymap) :void
+(cffi:defcfun ("rl_free_keymap" free-keymap) :void
   "Free all storage associated with KEYMAP."
   (keymap :pointer))
 
-(defcfun ("rl_get_keymap" get-keymap) :pointer
+(cffi:defcfun ("rl_get_keymap" get-keymap) :pointer
   "Return currently active keymap.")
 
-(defcfun ("rl_set_keymap" set-keymap) :void
+(cffi:defcfun ("rl_set_keymap" set-keymap) :void
   "Make KEYMAP the currently active keymap."
   (keymap :pointer))
 
-(defcfun ("rl_get_keymap_by_name" get-keymap-by-name) :pointer
+(cffi:defcfun ("rl_get_keymap_by_name" get-keymap-by-name) :pointer
   "Return the keymap matching NAME. NAME is one which would be supplied in a
 set keymap inputrc line."
   (name :string))
 
-(defcfun ("rl_get_keymap_name" get-keymap-name) :string
+(cffi:defcfun ("rl_get_keymap_name" get-keymap-name) :string
   "Return the name matching KEYMAP. Name is one which would be supplied in a
 set keymap inputrc line."
   (keymap :pointer))
@@ -637,7 +637,7 @@ function using `bind-key'. FUNCTION must be able to take two arguments:
 integer representing its argument and character representing key that has
 invoked it."
   (ensure-initialization)
-  (foreign-funcall "rl_add_defun"
+  (cffi:foreign-funcall "rl_add_defun"
                    :string name
                    :pointer (produce-callback function
                                               :boolean
@@ -652,24 +652,24 @@ bound."
   (ensure-initialization)
   (let ((cb (produce-callback* function :boolean '(:int int-char))))
     (cond ((and keymap if-unbound)
-           (foreign-funcall "rl_bind_key_if_unbound_in_map"
+           (cffi:foreign-funcall "rl_bind_key_if_unbound_in_map"
                             int-char key
                             :pointer cb
                             :pointer keymap
                             :boolean))
           (keymap
-           (foreign-funcall "rl_bind_key_in_map"
+           (cffi:foreign-funcall "rl_bind_key_in_map"
                             int-char key
                             :pointer cb
                             :pointer keymap
                             :boolean))
           (if-unbound
-           (foreign-funcall "rl_bind_key_if_unbound"
+           (cffi:foreign-funcall "rl_bind_key_if_unbound"
                             int-char key
                             :pointer cb
                             :boolean))
           (t
-           (foreign-funcall "rl_bind_key"
+           (cffi:foreign-funcall "rl_bind_key"
                             int-char key
                             :pointer cb
                             :boolean)))))
@@ -680,18 +680,18 @@ unbound in currently active keymap. The function returns NIL on success and
 T on failure."
   (ensure-initialization)
   (if keymap
-      (foreign-funcall "rl_unbind_key_in_map"
+      (cffi:foreign-funcall "rl_unbind_key_in_map"
                        int-char key
                        :pointer keymap
                        :boolean)
-      (foreign-funcall "rl_unbind_key"
+      (cffi:foreign-funcall "rl_unbind_key"
                        int-char key
                        :boolean)))
 
 (defun unbind-command (command keymap)
   "Unbind all keys that are bound to COMMAND in KEYMAP."
   (ensure-initialization)
-  (foreign-funcall "rl_unbind_command_in_map"
+  (cffi:foreign-funcall "rl_unbind_command_in_map"
                    :string command
                    :pointer keymap
                    :boolean))
@@ -706,24 +706,24 @@ if KEYSEQ is invalid and NIL otherwise."
   (ensure-initialization)
   (let ((cb (produce-callback* function :boolean '(:int int-char))))
     (cond ((and keymap if-unbound)
-           (foreign-funcall "rl_bind_keyseq_if_unbound_in_map"
+           (cffi:foreign-funcall "rl_bind_keyseq_if_unbound_in_map"
                             :string  keyseq
                             :pointer cb
                             :pointer keymap
                             :boolean))
           (keymap
-           (foreign-funcall "rl_bind_keyseq_in_map"
+           (cffi:foreign-funcall "rl_bind_keyseq_in_map"
                             :string  keyseq
                             :pointer cb
                             :pointer keymap
                             :boolean))
           (if-unbound
-           (foreign-funcall "rl_bind_keyseq_if_unbound"
+           (cffi:foreign-funcall "rl_bind_keyseq_if_unbound"
                             :string  keyseq
                             :pointer cb
                             :boolean))
           (t
-           (foreign-funcall "rl_bind_keyseq"
+           (cffi:foreign-funcall "rl_bind_keyseq"
                             :string  keyseq
                             :pointer cb
                             :boolean)))))
@@ -732,14 +732,14 @@ if KEYSEQ is invalid and NIL otherwise."
   "Parse LINE as if it had been read from the inputrc file and perform any
 key bindings and variable assignments found."
   (ensure-initialization)
-  (foreign-funcall "rl_parse_and_bind"
+  (cffi:foreign-funcall "rl_parse_and_bind"
                    :string line
                    :boolean))
 
 (defun read-init-file (filename)
   "Read keybindings and variable assignments from FILENAME."
   (ensure-initialization)
-  (foreign-funcall "rl_read_init_file"
+  (cffi:foreign-funcall "rl_read_init_file"
                    :string filename
                    :boolean))
 
@@ -758,7 +758,7 @@ supplied and it's a string or path, output will be redirected to the
 file. APPEND allows to append text to the file instead of overwriting it."
   (ensure-initialization)
   (with-possible-redirection filename append
-    (foreign-funcall "rl_function_dumper"
+    (cffi:foreign-funcall "rl_function_dumper"
                      :boolean readable
                      :void)))
 
@@ -768,25 +768,25 @@ is supplied and it's a string or path, output will be redirected to the
 file. APPEND allows append text to the file instead of overwriting it."
   (ensure-initialization)
   (with-possible-redirection filename append
-    (foreign-funcall "rl_list_funmap_names"
+    (cffi:foreign-funcall "rl_list_funmap_names"
                      :void)))
 
 (defun funmap-names ()
   "Return a list of known function names. The list is sorted."
   (ensure-initialization)
-  (let ((ptr (foreign-funcall "rl_funmap_names"
+  (let ((ptr (cffi:foreign-funcall "rl_funmap_names"
                               :pointer)))
-    (unless (null-pointer-p ptr)
+    (unless (cffi:null-pointer-p ptr)
       (unwind-protect
            (to-list-of-strings ptr)
-        (foreign-funcall "free"
+        (cffi:foreign-funcall "free"
                          :pointer ptr
                          :void)))))
 
 (defun add-funmap-entry (name function)
   "Add NAME to the list of bindable Readline command names, and make
 FUNCTION the function to be called when name is invoked."
-  (foreign-funcall "rl_add_funmap_entry"
+  (cffi:foreign-funcall "rl_add_funmap_entry"
                    :string name
                    :pointer (produce-callback function
                                               :boolean
@@ -804,11 +804,11 @@ FUNCTION the function to be called when name is invoked."
 into one undo operation."
   `(unwind-protect
         (progn
-          (foreign-funcall "rl_begin_undo_group" :boolean)
+          (cffi:foreign-funcall "rl_begin_undo_group" :boolean)
           ,@body)
-     (foreign-funcall "rl_end_undo_group" :boolean)))
+     (cffi:foreign-funcall "rl_end_undo_group" :boolean)))
 
-(defcfun ("rl_add_undo" add-undo) :void
+(cffi:defcfun ("rl_add_undo" add-undo) :void
   "Remember how to undo an event (according to WHAT). The affected text runs
 from START to END, and encompasses TEXT. Possible values of WHAT
 include: :UNDO-DELETE, :UNDO-INSERT, :UNDO-BEGIN, and :UNDO-END."
@@ -817,14 +817,14 @@ include: :UNDO-DELETE, :UNDO-INSERT, :UNDO-BEGIN, and :UNDO-END."
   (end   :int)
   (text  :string))
 
-(defcfun ("rl_free_undo_list" free-undo-list) :void
+(cffi:defcfun ("rl_free_undo_list" free-undo-list) :void
   "Free the existing undo list.")
 
-(defcfun ("rl_do_undo" do-undo) :boolean
+(cffi:defcfun ("rl_do_undo" do-undo) :boolean
   "Undo the first thing on the undo list. Returns NIL if there was nothing
 to undo, T if something was undone.")
 
-(defcfun ("rl_modifying" modifying) :boolean
+(cffi:defcfun ("rl_modifying" modifying) :boolean
   "Tell Readline to save the text between START and END as a single undo
 unit. It is assumed that you will subsequently modify that text."
   (start :int)
@@ -837,11 +837,11 @@ unit. It is assumed that you will subsequently modify that text."
 ;;                                                                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defcfun ("rl_redisplay" redisplay) :void
+(cffi:defcfun ("rl_redisplay" redisplay) :void
   "Change what's displayed on the screen to reflect the current contents of
 `*line-buffer*'.")
 
-(defcfun ("rl_forced_update_display" forced-update-display) :boolean
+(cffi:defcfun ("rl_forced_update_display" forced-update-display) :boolean
   "Force the line to be updated and redisplayed, whether or not Readline
 thinks the screen display is correct.")
 
@@ -853,17 +853,17 @@ applications that want to output the prompt string themselves, but still
 need Readline to know the prompt string length for redisplay. This should be
 used together with :ALREADY-PROMPTED keyword argument of `readline'."
   (if with-prompt
-      (foreign-funcall "rl_on_new_line_with_prompt" :boolean)
-      (foreign-funcall "rl_on_new_line" :boolean)))
+      (cffi:foreign-funcall "rl_on_new_line_with_prompt" :boolean)
+      (cffi:foreign-funcall "rl_on_new_line" :boolean)))
 
-(defcfun ("rl_reset_line_state" reset-line-state) :boolean
+(cffi:defcfun ("rl_reset_line_state" reset-line-state) :boolean
   "Reset the display state to a clean state and redisplay the current line
 starting on a new line.")
 
-(defcfun ("rl_crlf" crlf) :boolean
+(cffi:defcfun ("rl_crlf" crlf) :boolean
   "Move the cursor to the start of the next screen line.")
 
-(defcfun ("rl_show_char" show-char) :boolean
+(cffi:defcfun ("rl_show_char" show-char) :boolean
   "Display character CHAR on outstream. If Readline has not been set to
 display meta characters directly, this will convert meta characters to a
 meta-prefixed key sequence. This is intended for use by applications which
@@ -877,16 +877,16 @@ it before clearing the message."
   `(unwind-protect
         (progn
           (when ,save-prompt
-            (foreign-funcall "rl_save_prompt" :void))
-          (foreign-funcall "rl_message"
+            (cffi:foreign-funcall "rl_save_prompt" :void))
+          (cffi:foreign-funcall "rl_message"
                            :string ,message
                            :boolean)
           ,@body)
      (when ,save-prompt
-       (foreign-funcall "rl_restore_prompt" :void))
-     (foreign-funcall "rl_clear_message" :boolean)))
+       (cffi:foreign-funcall "rl_restore_prompt" :void))
+     (cffi:foreign-funcall "rl_clear_message" :boolean)))
 
-(defcfun ("rl_set_prompt" set-prompt) :boolean
+(cffi:defcfun ("rl_set_prompt" set-prompt) :boolean
   "Make Readline use PROMPT for subsequent redisplay. This calls
 `expand-prompt' to expand the prompt and sets `+prompt+' to the result."
   (prompt :string))
@@ -898,18 +898,18 @@ it before clearing the message."
 ;;                                                                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defcfun ("rl_insert_text" insert-text) :int
+(cffi:defcfun ("rl_insert_text" insert-text) :int
   "Insert TEXT into the line at the current cursor position. Return the
 number of characters inserted."
   (text :string))
 
-(defcfun ("rl_delete_text" delete-text) :int
+(cffi:defcfun ("rl_delete_text" delete-text) :int
   "Delete the text between START and END in the current line. Return the
 number of characters deleted."
   (start :int)
   (end   :int))
 
-(defcfun ("rl_kill_text" kill-text) :boolean
+(cffi:defcfun ("rl_kill_text" kill-text) :boolean
   "Copy the text between START and END in the current line to the kill ring,
 appending or prepending to the last kill if the last command was a kill
 command. The text is deleted. If START is less than END, the text is
@@ -925,26 +925,26 @@ kill ring slot is used."
 ;;                                                                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defcfun ("rl_read_key" read-key) int-char
+(cffi:defcfun ("rl_read_key" read-key) int-char
   "Return the next character available from Readline's current input
 stream.")
 
-(defcfun ("rl_stuff_char" stuff-char) :boolean
+(cffi:defcfun ("rl_stuff_char" stuff-char) :boolean
   "Insert CHAR into the Readline input stream. It will be «read» before
 Readline attempts to read characters from the terminal with `read-key'. Up
 to 512 characters may be pushed back. `stuff-char' returns T if the
 character was successfully inserted; NIL otherwise."
   (char int-char))
 
-(defcfun ("rl_execute_next" execute-next) :boolean
+(cffi:defcfun ("rl_execute_next" execute-next) :boolean
   "Make CHAR be the next command to be executed when `read-key' is called."
   (char int-char))
 
-(defcfun ("rl_clear_pending_input" clear-pending-input) :boolean
+(cffi:defcfun ("rl_clear_pending_input" clear-pending-input) :boolean
   "Negate the effect of any previous call to `execute-next'. This works only
 if the pending input has not already been read with `read-key'.")
 
-(defcfun ("rl_set_keyboard_input_timeout" set-keyboard-input-timeout) :int
+(cffi:defcfun ("rl_set_keyboard_input_timeout" set-keyboard-input-timeout) :int
   "While waiting for keyboard input in `read-key', Readline will wait for U
 microseconds for input before calling any function assigned to `event-hook'.
 U must be greater than or equal to zero (a zero-length timeout is equivalent
@@ -977,7 +977,7 @@ old timeout value."
 (defun forward-byte (&optional (count 1) key)
   "Move forward COUNT bytes (1 by default)."
   (declare (ignore key))
-  (foreign-funcall "rl_forward_byte"
+  (cffi:foreign-funcall "rl_forward_byte"
                    :int count
                    :int 0
                    :int))
@@ -985,7 +985,7 @@ old timeout value."
 (defun backward-byte (&optional (count 1) key)
   "Move backward COUNT bytes (1 by default)."
   (declare (ignore key))
-  (foreign-funcall "rl_backward_byte"
+  (cffi:foreign-funcall "rl_backward_byte"
                    :int count
                    :int 0
                    :int))
@@ -995,7 +995,7 @@ old timeout value."
 
   KEY is ignored."
   (declare (ignore key))
-  (foreign-funcall "rl_backward_char"
+  (cffi:foreign-funcall "rl_backward_char"
                    :int count
                    :int 0
                    :int))
@@ -1003,7 +1003,7 @@ old timeout value."
 (defun forward-char (&optional (count 1) key)
   "Move forward COUNT characters (1 by default)."
   (declare (ignore key))
-  (foreign-funcall "rl_forward_char"
+  (cffi:foreign-funcall "rl_forward_char"
                    :int count
                    :int 1
                    :int))
@@ -1011,7 +1011,7 @@ old timeout value."
 (defun beginning-of-line (&optional (count 1) key)
   "Move to the beginning of the line. "
   (declare (ignore key))
-  (foreign-funcall "rl_beg_of_line"
+  (cffi:foreign-funcall "rl_beg_of_line"
                    :int count
                    :int 0
                    :int))
@@ -1019,7 +1019,7 @@ old timeout value."
 (defun end-of-line (&optional (count 1) key)
   "Move to the end of the line. "
   (declare (ignore key))
-  (foreign-funcall "rl_end_of_line"
+  (cffi:foreign-funcall "rl_end_of_line"
                    :int count
                    :int 0
                    :int))
@@ -1029,7 +1029,7 @@ old timeout value."
 
   We do what Emacs does. Handles multibyte chars."
   (declare (ignore key))
-  (foreign-funcall "rl_forward_word"
+  (cffi:foreign-funcall "rl_forward_word"
                    :int count
                    :int 0
                    :int))
@@ -1039,7 +1039,7 @@ old timeout value."
 
   We do what Emacs does. Handles multibyte chars."
   (declare (ignore key))
-  (foreign-funcall "rl_backward_word"
+  (cffi:foreign-funcall "rl_backward_word"
                    :int count
                    :int 0
                    :int))
@@ -1047,7 +1047,7 @@ old timeout value."
 (defun refresh-line (&optional (count 1) key)
   "Clear the current line. Numeric argument to C-l does this."
   (declare (ignore key))
-  (foreign-funcall "rl_refresh_line"
+  (cffi:foreign-funcall "rl_refresh_line"
                    :int count
                    :int 0
                    :int))
@@ -1057,7 +1057,7 @@ old timeout value."
 
   Given a numeric arg, redraw only the current line."
   (declare (ignore key))
-  (foreign-funcall "rl_clear_screen"
+  (cffi:foreign-funcall "rl_clear_screen"
                    :int count
                    :int 0
                    :int))
@@ -1065,7 +1065,7 @@ old timeout value."
 (defun clear-display (&optional (count 1) key)
   "Clear the screen and update the display."
   (declare (ignore key))
-  (foreign-funcall "rl_clear_display"
+  (cffi:foreign-funcall "rl_clear_display"
                    :int count
                    :int 0
                    :int))
@@ -1079,13 +1079,13 @@ old timeout value."
 ;;                                                                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defcfun ("rl_prep_terminal" prep-terminal) :void
+(cffi:defcfun ("rl_prep_terminal" prep-terminal) :void
   "Modify the terminal settings for Readline's use, so `readline' can read a
 single character at a time from the keyboard. The EIGHT-BIT-INPUT argument
 should be non-NIL if Readline should read eight-bit input."
   (eight-bit-input :boolean))
 
-(defcfun ("rl_deprep_terminal" deprep-terminal) :void
+(cffi:defcfun ("rl_deprep_terminal" deprep-terminal) :void
   "Undo the effects of `prep-terminal', leaving the terminal in the state in
 which it was before the most recent call to `prep-terminal'.")
 
@@ -1094,17 +1094,17 @@ which it was before the most recent call to `prep-terminal'.")
 displayed by stty) to their Readline equivalents. The bindings are performed
 in KEYMAP."
   (ensure-initialization)
-  (foreign-funcall "rl_tty_set_default_bindings"
+  (cffi:foreign-funcall "rl_tty_set_default_bindings"
                    :pointer keymap
                    :void))
 
-(defcfun ("rl_tty_unset_default_bindings" tty-unset-default-bindings) :void
+(cffi:defcfun ("rl_tty_unset_default_bindings" tty-unset-default-bindings) :void
   "Reset the bindings manipulated by `tty-set-default-bindings' so that the
 terminal editing characters are bound to `insert'. The bindings are
 performed in KEYMAP."
   (keymap :pointer))
 
-(defcfun ("rl_reset_terminal" reset-terminal) :boolean
+(cffi:defcfun ("rl_reset_terminal" reset-terminal) :boolean
   "Reinitialize Readline's idea of the terminal settings using TERMINAL as
 the terminal type (e.g., vt100)."
   (terminal :string))
@@ -1115,23 +1115,23 @@ the terminal type (e.g., vt100)."
 ;;                                                                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defcfun ("rl_replace_line" replace-line) :void
+(cffi:defcfun ("rl_replace_line" replace-line) :void
   "Replace the contents of `*line-buffer*' with TEXT. The point and mark are
 preserved, if possible. If CLEAR-UNDO is non-NIL, the undo list associated
 with the current line is cleared."
   (text       :string)
   (clear-undo :boolean))
 
-(defcfun ("rl_extend_line_buffer" extend-line-buffer) :void
+(cffi:defcfun ("rl_extend_line_buffer" extend-line-buffer) :void
   "Ensure that line buffer has enough space to hold LEN characters,
 possibly reallocating it if necessary."
   (len :int))
 
-(defcfun ("rl_initialize" initialize) :boolean
+(cffi:defcfun ("rl_initialize" initialize) :boolean
   "Initialize or re-initialize Readline's internal state. It's not strictly
 necessary to call this; `readline' calls it before reading any input.")
 
-(defcfun ("rl_ding" ding) :boolean
+(cffi:defcfun ("rl_ding" ding) :boolean
   "Ring the terminal bell, obeying the setting of bell-style.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1149,7 +1149,7 @@ the file. APPEND allows to append text to the file instead of overwriting
 it."
   (ensure-initialization)
   (with-possible-redirection filename append
-    (foreign-funcall "rl_macro_dumper"
+    (cffi:foreign-funcall "rl_macro_dumper"
                      :boolean readable
                      :void)))
 
@@ -1157,7 +1157,7 @@ it."
   "Make the Readline variable VARIABLE have VALUE. This behaves as if the
 readline command 'set variable value' had been executed in an inputrc file."
   (ensure-initialization)
-  (foreign-funcall "rl_variable_bind"
+  (cffi:foreign-funcall "rl_variable_bind"
                    :string variable
                    :string value
                    :boolean))
@@ -1166,7 +1166,7 @@ readline command 'set variable value' had been executed in an inputrc file."
   "Return a string representing the value of the Readline variable
 VARIABLE. For Boolean variables, this string is either 'on' or 'off'."
   (ensure-initialization)
-  (foreign-funcall "rl_variable_value"
+  (cffi:foreign-funcall "rl_variable_value"
                    :string variable
                    :string))
 
@@ -1178,29 +1178,29 @@ string or path, output will be redirected to the file. APPEND allows to
 append text to the file instead of overwriting it."
   (ensure-initialization)
   (with-possible-redirection filename append
-    (foreign-funcall "rl_variable_dumper"
+    (cffi:foreign-funcall "rl_variable_dumper"
                      :boolean readable
                      :void)))
 
-(defcvar ("rl_blink_matching_paren" *blink-matching-paren*) :boolean
+(cffi:defcvar ("rl_blink_matching_paren" *blink-matching-paren*) :boolean
   "If this variable is non-NIL, matching parenthesis (if its key is bound to
 rl_insert_close) will blink whenever the closing parenthesis is inserted.")
 
-(defcfun ("rl_set_paren_blink_timeout" set-paren-blink-timeout) :int
+(cffi:defcfun ("rl_set_paren_blink_timeout" set-paren-blink-timeout) :int
   "Set the time interval (in microseconds) that Readline waits when showing
 a balancing character when 'blink-matching-paren' has been enabled. The
 function returns previous value of the parameter."
   (micros :int))
 
-(defcfun ("rl_clear_history" clear-history) :void
+(cffi:defcfun ("rl_clear_history" clear-history) :void
   "Clear the history list by deleting all of the entries.")
 
-(defcfun ("read_history" read-history) :int
+(cffi:defcfun ("read_history" read-history) :int
   "Add the contents of filename to the history list, a line at a
 time."
   (filename :string))
 
-(defcfun ("write_history" write-history) :int
+(cffi:defcfun ("write_history" write-history) :int
   "Write the current history to filename, overwriting filename if
 necessary."
   (filename :string))
@@ -1212,25 +1212,25 @@ necessary."
 ;;                                                                        ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defcfun ("rl_cleanup_after_signal" cleanup-after-signal) :void
+(cffi:defcfun ("rl_cleanup_after_signal" cleanup-after-signal) :void
   "This function will reset the state of the terminal to what it was before
 `readline' was called, and remove the Readline signal handlers for all
 signals, depending on the values of `*catch-signals*' and
 `*catch-sigwinch*'.")
 
-(defcfun ("rl_free_line_state" free-line-state) :void
+(cffi:defcfun ("rl_free_line_state" free-line-state) :void
   "This will free any partial state associated with the current input
 line (undo information, any partial history entry, any partially-entered
 keyboard macro, and any partially-entered numeric argument). This should be
 called before `cleanup-after-signal.' The Readline signal handler for SIGINT
 calls this to abort the current input line.")
 
-(defcfun ("rl_reset_after_signal" reset-after-signal) :void
+(cffi:defcfun ("rl_reset_after_signal" reset-after-signal) :void
   "This will reinitialize the terminal and reinstall any Readline signal
 handlers, depending on the values of `*catch-signals*' and
 `*catch-sigwinch*'.")
 
-(defcfun ("rl_echo_signal_char" echo-signal-char) :void
+(cffi:defcfun ("rl_echo_signal_char" echo-signal-char) :void
   "If an application wishes to install its own signal handlers, but still
 have readline display characters that generate signals, calling this
 function with SIG set to :SIGINT, :SIGQUIT, or :SIGTSTP will display the
@@ -1241,10 +1241,10 @@ character generating that signal."
   "Update Readline's internal screen size by reading values from the
 kernel."
   (ensure-initialization)
-  (foreign-funcall "rl_resize_terminal"
+  (cffi:foreign-funcall "rl_resize_terminal"
                    :void))
 
-(defcfun ("rl_set_screen_size" set-screen-size) :void
+(cffi:defcfun ("rl_set_screen_size" set-screen-size) :void
   "Set Readline's idea of the terminal size to ROWS rows and COLS
 columns. If either rows or columns is less than or equal to 0, Readline's
 idea of that terminal dimension is unchanged."
@@ -1257,21 +1257,21 @@ multiple values: number of rows and columns."
   (ensure-initialization)
   (cffi:with-foreign-objects ((rows :int)
                          (cols :int))
-    (foreign-funcall "rl_get_screen_size"
+    (cffi:foreign-funcall "rl_get_screen_size"
                      :pointer rows
                      :pointer cols
                      :void)
     (values (cffi:mem-ref rows :int)
-            (mem-ref cols :int))))
+            (cffi:mem-ref cols :int))))
 
-(defcfun ("rl_reset_screen_size" reset-screen-size) :void
+(cffi:defcfun ("rl_reset_screen_size" reset-screen-size) :void
   "Cause Readline to reobtain the screen size and recalculate its
 dimensions.")
 
-(defcfun ("rl_set_signals" set-signals) :boolean
+(cffi:defcfun ("rl_set_signals" set-signals) :boolean
   "Install Readline's signal handler for SIGINT, SIGQUIT, SIGTERM, SIGHUP,
 SIGALRM, SIGTSTP, SIGTTIN, SIGTTOU, and SIGWINCH, depending on the values of
 `*catch-signals*' and `*catch-sigwinch*'.")
 
-(defcfun ("rl_clear_signals" clear-signals) :boolean
+(cffi:defcfun ("rl_clear_signals" clear-signals) :boolean
   "Remove all of the Readline signal handlers installed by `set-signals'.")

--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -19,7 +19,7 @@
 
 (in-package #:cl-readline)
 
-(define-foreign-library readline
+(cffi:define-foreign-library readline
   ;; On OSX we first search readline, installed by brew install readline
   ;; because native system version of readline is a symlink to libedit.
   ;; Some people on the internet advice to "fix" it by running:
@@ -43,7 +43,7 @@
 		 "libreadline.dll"))
   (t       (:default "libreadline")))
 
-(use-foreign-library readline)
+(cffi:use-foreign-library readline)
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -416,12 +416,12 @@ actual string and NIL on failure."
                                :pointer)))
     (unless (null-pointer-p ptr))
       (unwind-protect
-           (let ((str (foreign-string-to-lisp ptr)))
+           (let ((str (cffi:foreign-string-to-lisp ptr)))
              (when (and add-history
-                        (not (emptyp str))
+                        (not (alexandria:emptyp str))
                         (or (not novelty-check)
                             (recent-history-line-satisfies-p
-                             (curry novelty-check str))))
+                             (alexandria:curry novelty-check str))))
                (foreign-funcall "add_history"
                                 :string str
                                 :void))
@@ -1255,13 +1255,13 @@ idea of that terminal dimension is unchanged."
   "Return Readline's idea of the terminal's size. The function returns
 multiple values: number of rows and columns."
   (ensure-initialization)
-  (with-foreign-objects ((rows :int)
+  (cffi:with-foreign-objects ((rows :int)
                          (cols :int))
     (foreign-funcall "rl_get_screen_size"
                      :pointer rows
                      :pointer cols
                      :void)
-    (values (mem-ref rows :int)
+    (values (cffi:mem-ref rows :int)
             (mem-ref cols :int))))
 
 (defcfun ("rl_reset_screen_size" reset-screen-size) :void

--- a/ctypes.lisp
+++ b/ctypes.lisp
@@ -42,7 +42,7 @@ and list of keywords.")
   :vi
   :emacs)
 
-(defcstruct history-entry
+(cffi:defcstruct history-entry
   "C structure that represents a history entry in Readline."
   (line :pointer)
   (time :pointer)

--- a/ctypes.lisp
+++ b/ctypes.lisp
@@ -19,25 +19,25 @@
 
 (in-package :cl-readline)
 
-(defctype int-char
+(cffi:defctype int-char
     (:wrapper :int
               :from-c code-char
               :to-c   char-code)
   "Wrapper for conversion between C int and Lisp character.")
 
-(defctype version
+(cffi:defctype version
     (:wrapper :int
               :from-c decode-version)
   "Wrapper for conversion between raw C int representing version of Readline
 library and Lisp values.")
 
-(defctype state
+(cffi:defctype state
     (:wrapper :int
               :from-c decode-state)
   "Wrapper for conversion between raw C int representing state of Readline
 and list of keywords.")
 
-(defcenum editing-mode
+(cffi:defcenum editing-mode
   "Enumeration of all possible editing modes in Readline."
   :vi
   :emacs)
@@ -48,14 +48,14 @@ and list of keywords.")
   (time :pointer)
   (data :pointer))
 
-(defcenum undo-code
+(cffi:defcenum undo-code
   "This enumeration contains codes for various types of undo operations."
   :undo-delete
   :undo-insert
   :undo-begin
   :undo-end)
 
-(defcenum unix-signal
+(cffi:defcenum unix-signal
   "Enumeration of some Unix signals for use with some Readline functions,
 see section «Signal Handling»."
   (:sighup  1)
@@ -67,7 +67,7 @@ see section «Signal Handling»."
   (:sigttin 26)
   (:sigttou 27))
 
-(defcenum completion-type
+(cffi:defcenum completion-type
   "Types of completion performed by Readline. See description of
 `+completion-type+' for more information."
   (:standard-completion 9)

--- a/package.lisp
+++ b/package.lisp
@@ -20,14 +20,6 @@
 (defpackage   :cl-readline
   (:nicknames :rl)
   (:use #:common-lisp)
-  (:import-from #:cffi
-                #:defcenum
-                #:defcfun
-                #:defcvar
-                #:foreign-funcall
-                #:mem-aref
-                #:null-pointer
-                #:null-pointer-p)
   (:export
    ;; Readline Variables
    #:*line-buffer*

--- a/package.lisp
+++ b/package.lisp
@@ -19,9 +19,15 @@
 
 (defpackage   :cl-readline
   (:nicknames :rl)
-  (:use       #:common-lisp
-              #:alexandria
-              #:cffi)
+  (:use #:common-lisp)
+  (:import-from #:cffi
+                #:defcenum
+                #:defcfun
+                #:defcvar
+                #:foreign-funcall
+                #:mem-aref
+                #:null-pointer
+                #:null-pointer-p)
   (:export
    ;; Readline Variables
    #:*line-buffer*

--- a/utils.lisp
+++ b/utils.lisp
@@ -63,7 +63,7 @@ list of components that can appear in result list."
   (mapcan (lambda (index keyword)
             (when (logbitp index state)
               (list keyword)))
-          (iota (length +states+))
+          (alexandria:iota (length +states+))
           +states+))
 
 (defmacro produce-callback (function return-type &optional func-arg-list)
@@ -75,9 +75,9 @@ can be ommited if FUNCTION doesn't take any arguments)."
     (with-gensyms (temp)
       `(if ,function
            (progn
-             (defcallback ,temp ,return-type ,gensymed-list
+             (cffi:defcallback ,temp ,return-type ,gensymed-list
                (funcall ,function ,@(mapcar #'car gensymed-list)))
-             (get-callback ',temp))
+             (cffi:get-callback ',temp))
            (null-pointer)))))
 
 (defun produce-callback* (function return-type &optional func-arg-list)
@@ -101,7 +101,7 @@ to into list of Lisp strings."
       (do ((i 0 (1+ i)))
           ((null-pointer-p (mem-aref pointer :pointer i))
            (reverse result))
-        (push (foreign-string-to-lisp (mem-aref pointer :pointer i))
+        (push (cffi:foreign-string-to-lisp (mem-aref pointer :pointer i))
               result)))))
 
 (defun to-array-of-strings (list)
@@ -113,7 +113,7 @@ strings. Memory for every string and the array itself should be freed with
              (ptr (foreign-funcall "malloc"
                                    :unsigned-int
                                    (* (1+ len)
-                                      (foreign-type-size :pointer))
+                                      (cffi:foreign-type-size :pointer))
                                    :pointer)))
         (setf (mem-aref ptr :pointer len)
               (null-pointer))
@@ -127,5 +127,5 @@ strings. Memory for every string and the array itself should be freed with
                                              (foreign-type-size :char))
                                           :pointer)))
             (setf (mem-aref ptr :pointer i)
-                  (lisp-string-to-foreign string buffer +c-buffer-size+)))))
+                  (cffi:lisp-string-to-foreign string buffer +c-buffer-size+)))))
       (null-pointer)))


### PR DESCRIPTION
- removed :use of #:alexandria and #:cffi
- added :import-from clause for regularly used external symbols (> 3 times)
- added package-specifier to rarely used external symbols (<= 3 times)

Hello! :-)

As discussed in [issue 24](https://github.com/vindarel/cl-readline/issues/24) here is my first merge request.
It took me a while to write a view functions to support this task.
So if you don't like my arbitrary choice of the differentiation between rare and regular use, fell free to complain,
since it would be fast to change.
Could the replacement of :use for external libraries be a feature for colisper or is the task too rare and complicated?

Since I didn't find automated tests, I only inspected the diffs of all four lisp files...
