### PR TITLE
Add two missing cffi package specifiers

### DIFF
--- a/cl-readline.lisp
+++ b/cl-readline.lisp
@@ -375,8 +375,8 @@ PREDICATE. Return T if there is no history saved."
     (if (zerop +history-length+)
         t
         (funcall predicate
-                 (foreign-string-to-lisp
-                  (with-foreign-slots
+                 (cffi:foreign-string-to-lisp
+                  (cffi:with-foreign-slots
                       ((line)
                        (cffi:foreign-funcall "history_get"
                                         :int (1- (+ +history-base+


### PR DESCRIPTION
Fixes the failure reported in
http://report.quicklisp.org/2025-05-01/failure-report/cl-readline.html
